### PR TITLE
Only show feedback on page given

### DIFF
--- a/js-extensions/packages/feedback/lib/index.tsx
+++ b/js-extensions/packages/feedback/lib/index.tsx
@@ -1,17 +1,23 @@
 import React from "react";
 import * as ReactDOM from "react-dom/client";
 import Highlighter from "web-highlighter";
+import HighlightSource from "web-highlighter/dist/model/source";
 
 import "../feedback.scss";
 import FeedbackRenderer from "./renderer";
 import SelectionRenderer from "./selection";
-import { HIGHLIGHT_STORAGE_KEY } from "./utils";
+import { HIGHLIGHT_STORAGE_KEY, HighlightExtra } from "./utils";
 
 let initFeedback = () => {
   let highlighter = new Highlighter();
 
+  // fetch stored highlights for current page from local storage
   let stored = localStorage.getItem(HIGHLIGHT_STORAGE_KEY);
-  let stored_parsed = JSON.parse(stored || "[]");
+  let stored_parsed: HighlightSource[] = JSON.parse(stored || "[]");
+  stored_parsed = stored_parsed.filter(h => {
+    let extra: HighlightExtra = JSON.parse(h.extra as string);
+    return extra.page === window.location.pathname;
+  });
 
   let div = document.createElement("div");
   let page = document.querySelector(".page")!;
@@ -24,7 +30,7 @@ let initFeedback = () => {
       <FeedbackRenderer highlighter={highlighter} />
 
       {/* render tooltip over user's current selection */}
-      <SelectionRenderer highlighter={highlighter} stored={stored_parsed as any[]} />
+      <SelectionRenderer highlighter={highlighter} stored={stored_parsed} />
     </>
   );
 };

--- a/js-extensions/packages/feedback/lib/modal.tsx
+++ b/js-extensions/packages/feedback/lib/modal.tsx
@@ -25,7 +25,12 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, close
 
   const handleSubmit = () => {
     // add feedback to serialized highlighter data (dispose hook after use)
-    let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => feedback.current!.value);
+    let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() =>
+      JSON.stringify({
+        text: feedback.current!.value,
+        page: window.location.pathname,
+      })
+    );
     highlighter.fromRange(range);
     dispose();
 

--- a/js-extensions/packages/feedback/lib/renderer.tsx
+++ b/js-extensions/packages/feedback/lib/renderer.tsx
@@ -38,7 +38,8 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
   let id = highlightHovered || tooltipHovered;
   if (id) {
     let el = highlighter.getDoms(id);
-    let feedback = highlighter.cache.get(id).extra as string;
+    let extra = highlighter.cache.get(id).extra as string;
+    let feedback = JSON.parse(extra || "{}").text;
 
     const reference: VirtualElement = {
       getBoundingClientRect: el[0].getBoundingClientRect.bind(el[0]),

--- a/js-extensions/packages/feedback/lib/selection.tsx
+++ b/js-extensions/packages/feedback/lib/selection.tsx
@@ -1,12 +1,13 @@
 import { VirtualElement } from "@popperjs/core";
 import React, { useCallback, useEffect, useState } from "react";
 import Highlighter from "web-highlighter";
+import HighlightSource from "web-highlighter/dist/model/source";
 
 import FeedbackModal from "./modal";
 import FeedbackTooltip from "./tooltip";
 import { HIGHLIGHT_STORAGE_KEY } from "./utils";
 
-type SelectionRendererProps = { highlighter: Highlighter; stored?: any[] };
+type SelectionRendererProps = { highlighter: Highlighter; stored?: HighlightSource[] };
 let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored }) => {
   // current highlighted range of text
   const [currRange, setCurrRange] = useState<Range | null>(null);

--- a/js-extensions/packages/feedback/lib/utils.ts
+++ b/js-extensions/packages/feedback/lib/utils.ts
@@ -1,1 +1,9 @@
 export const HIGHLIGHT_STORAGE_KEY = "mdbook-quiz:highlights";
+
+/** Stored in the `extra` field of a `HighlightSource` as a string */
+export type HighlightExtra = {
+  /** Feedback submitted by user */
+  text: string;
+  /** Path to page on which feedback was given */
+  page: string;
+};


### PR DESCRIPTION
This PR appends the current page path (`window.location.pathname`) to the `extra` field stored in local storage. This value is used to filter which highlights should be rendered, fixing the current issue where all highlights are shown regardless of which page they were created.

The `extra` field is still a string, but instead of only being the text the user submitted as feedback, it's now a stringified object with a `text` attribute (user's feedback) and `page` attribute.