### PR TITLE
Fix issues with tooltip/feedback not working iOS

### DIFF
--- a/js-extensions/packages/feedback/feedback.scss
+++ b/js-extensions/packages/feedback/feedback.scss
@@ -107,15 +107,16 @@
   border-right: 1px solid var(--popper-bg-hover);
 }
 
-.modal-textarea-helper {
-  font-size: 0.75em;
-  color: #ff0033;
-}
-
 .ReactModal__Overlay {
   z-index: 101; // must be >= #menu-bar z-index
 
   textarea {
     font-family: 'Open Sans', sans-serif;
+    min-width: 250px;
+  }
+
+  button, textarea {
+    // safari won't zoom in on input if font-size >= 16px
+    font-size: 16px;
   }
 }

--- a/js-extensions/packages/feedback/lib/modal.tsx
+++ b/js-extensions/packages/feedback/lib/modal.tsx
@@ -39,14 +39,7 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, close
 
   return (
     <Modal style={modalStyles} contentLabel="Feedback Modal" onRequestClose={closeModal} isOpen>
-      <textarea
-        autoFocus
-        ref={feedback}
-        style={{ minWidth: "250px" }}
-        rows={4}
-        placeholder="Your note..."
-        required
-      ></textarea>
+      <textarea autoFocus ref={feedback} rows={4} placeholder="Your note..." required></textarea>
       <br />
       <button onClick={handleSubmit}>Submit</button>
     </Modal>

--- a/js-extensions/packages/feedback/lib/renderer.tsx
+++ b/js-extensions/packages/feedback/lib/renderer.tsx
@@ -32,6 +32,9 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
     // cursor must be over tooltip when deleting, so use tooltip ID
     highlighter.remove(tooltipHovered!);
     setTooltipHovered(null);
+
+    // on mobile, the highlight isn't unhovered, so also reset
+    setHighlightHovered(null);
   };
 
   // If hovering over existing highlight or tooltip, render tooltip
@@ -52,7 +55,12 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
       >
         <div className="pop-feedback-container">
           {feedback != "" ? <div className="pop-feedback-text">{feedback}</div> : null}
-          <div className="pop-button" onClick={removeFeedback} title="Delete feedback">
+          <div
+            className="pop-button"
+            onClick={removeFeedback}
+            onTouchStart={removeFeedback}
+            title="Delete feedback"
+          >
             &#128465;
           </div>
         </div>

--- a/js-extensions/packages/feedback/lib/selection.tsx
+++ b/js-extensions/packages/feedback/lib/selection.tsx
@@ -76,6 +76,7 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
           <div
             className="pop-button"
             onClick={() => setModalOpen(true)}
+            onTouchStart={() => setModalOpen(true)}
             title="Provide feedback on this content"
           >
             ✏️

--- a/js-extensions/packages/feedback/lib/tooltip.tsx
+++ b/js-extensions/packages/feedback/lib/tooltip.tsx
@@ -22,8 +22,13 @@ const FeedbackTooltip: React.FC<FeedbackTooltipProps> = ({
 
   useEffect(() => {
     if (onHoverChange && popperElement) {
+      // mouse/laptop touchpad listeners
       popperElement.addEventListener("mouseenter", () => onHoverChange(true));
       popperElement.addEventListener("mouseleave", () => onHoverChange(false));
+
+      // mobile listeners
+      popperElement.addEventListener("touchstart", () => onHoverChange(true));
+      popperElement.addEventListener("touchend", () => onHoverChange(false));
     }
   }, [popperElement]);
 


### PR DESCRIPTION
This PR fixes a couple issues when using the new feedback feature on iOS (safari).

## Issues fixed

### Tooltips don't click correctly
This turned out to be an issue with the listener attached to the clickable divs. The existing `onClick` listeners weren't firing, so I added `onTouchStart` listeners to open the modal and remove feedback on mobile. I did a similar thing within `tooltip.tsx`, which wasn't correctly tracking hovers on mobile since the listeners were mouse-specific.

### When the modal opens, the browser zooms in to the textarea
I guess webkit has a weird preset where, if the input has a `font-size` < 16px, it zooms in for you. Fixed this by making the fonts in the modal 16px.