### PR TITLE
Bring back transparent border for feedback tooltip

### DIFF
--- a/js-extensions/packages/feedback/feedback.scss
+++ b/js-extensions/packages/feedback/feedback.scss
@@ -35,12 +35,17 @@
   padding: 5px 8px;
   display: inline-block;
   border-radius: 5px;
+  background-clip: padding-box;
+}
 
-  // // TODO: will tried removing this and it didn't seem to change any behavior?
-  // // prevent tooltip dissapearing when cursor moves between
-  // // highlight and tooltip
-  // border-bottom: 8px solid transparent;
-  // background-clip: padding-box;
+// prevent tooltip dissapearing when cursor moves between
+// highlight and tooltip by adding transparent border between
+// the two
+.pop-top {
+  border-bottom: 8px solid transparent;
+}
+.pop-bottom {
+  border-top: 8px solid transparent;
 }
 
 .pop-arrow,

--- a/js-extensions/packages/feedback/lib/tooltip.tsx
+++ b/js-extensions/packages/feedback/lib/tooltip.tsx
@@ -40,7 +40,7 @@ const FeedbackTooltip: React.FC<FeedbackTooltipProps> = ({
   return (
     <div
       ref={setPopperElement}
-      className="pop"
+      className={`pop pop-${placement}`}
       onMouseDown={handleTooltipClick}
       style={styles.popper}
       {...attributes.popper}


### PR DESCRIPTION
This PR re-introduces a previously-removed transparent border between the highlighted text and tooltip. This adds some spacing between the two but also _very slightly_ changes the look of the tooltip because the border radius no longer exists on the side facing the highlight.

## Previous tooltip position (wide screen)
![image](https://user-images.githubusercontent.com/40175891/183792705-1b0739ab-3cf7-40c9-bc72-f7a8af5e97a8.png)

## New tooltip position (wide screen)
![image](https://user-images.githubusercontent.com/40175891/183792803-72f5beca-d087-4d14-a4c5-643bcbd592fb.png)

## Previous tooltip position (mobile)
![image](https://user-images.githubusercontent.com/40175891/183793221-32be1caa-c488-424d-a758-063b8480f02d.png)

## New tooltip position (mobile)
![image](https://user-images.githubusercontent.com/40175891/183793210-b8ce514c-fcbb-40da-93f6-753cc4dc2fec.png)
