### PR TITLE
Add transparent border to existing feedback tooltip

### DIFF
--- a/js-extensions/packages/feedback/lib/renderer.tsx
+++ b/js-extensions/packages/feedback/lib/renderer.tsx
@@ -52,6 +52,7 @@ const FeedbackRenderer: React.FC<FeedbackRendererProps> = ({ highlighter }) => {
       <FeedbackTooltip
         reference={reference}
         onHoverChange={isHovered => setTooltipHovered(isHovered ? highlightHovered : null)}
+        placement="top"
       >
         <div className="pop-feedback-container">
           {feedback != "" ? <div className="pop-feedback-text">{feedback}</div> : null}


### PR DESCRIPTION
Something I missed in #3 - tooltips for existing feedback don't have a `placement` and thus don't have the `pop-top` or `pop-bottom` classes which add the transparent border:

![Screenshot from 2022-08-11 20-16-57](https://user-images.githubusercontent.com/40175891/184267657-7266200f-6218-4c07-a3e0-5edb1268b921.png)

After this PR:

![Screenshot from 2022-08-11 20-17-13](https://user-images.githubusercontent.com/40175891/184267662-20e43c48-eecc-4584-830d-1e74fcd5ca93.png)

