### PR TITLE
Log more information about feedback + log removed highlights

### DIFF
--- a/js-extensions/packages/feedback/lib/modal.tsx
+++ b/js-extensions/packages/feedback/lib/modal.tsx
@@ -30,7 +30,6 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ range, highlighter, close
       text: feedback.current!.value,
       page: window.location.pathname,
     };
-    window.telemetry.log("feedback", data);
 
     let dispose = highlighter.hooks.Serialize.RecordInfo.tap(() => JSON.stringify(data));
     highlighter.fromRange(range);

--- a/js-extensions/packages/feedback/lib/utils.ts
+++ b/js-extensions/packages/feedback/lib/utils.ts
@@ -7,3 +7,8 @@ export type HighlightExtra = {
   /** Path to page on which feedback was given */
   page: string;
 };
+
+export enum HighlightTelemetryAction {
+  create = "create",
+  remove = "remove",
+}


### PR DESCRIPTION
This PR modifies the logging done by the feedback system. It moves all logging into web-highlighter's "hooks" (`Highlighter.event.CREATE` and `Highlighter.event.REMOVE`). Instead of logging just the text from the user and the page from which they logged, the entire `HighlightSource` (used to reconstruct the highlight and render on the page) is logged. Additionally, the ID of deleted highlights is logged.

Here's an example of what `feedback.log` will look like:
```json
{"commitHash":"ad0737f858949d7afbecc584b89f6ed8b84b3444\n","payload":{"action":"create","data":{"__isHighlightSource":{},"endMeta":{"parentIndex":5,"parentTagName":"P","textOffset":20},"extra":{"page":"/","text":"My feedback! (soon to be deleted)"},"id":"bfe1d4da-9de1-43d8-9a05-05a1203383cf","startMeta":{"parentIndex":5,"parentTagName":"P","textOffset":7},"text":"spot an issue"}},"sessionId":"51bbd2a7-c4fd-4949-b609-baa76b8d45b9","timestamp":1660872705257}
{"commitHash":"ad0737f858949d7afbecc584b89f6ed8b84b3444\n","payload":{"action":"create","data":{"__isHighlightSource":{},"endMeta":{"parentIndex":7,"parentTagName":"P","textOffset":30},"extra":{"page":"/","text":"More feedback!"},"id":"aeb700e1-02b5-4808-95ee-074d62b022dc","startMeta":{"parentIndex":7,"parentTagName":"P","textOffset":3},"text":"Try highlighting this text!"}},"sessionId":"51bbd2a7-c4fd-4949-b609-baa76b8d45b9","timestamp":1660872712076}
{"commitHash":"ad0737f858949d7afbecc584b89f6ed8b84b3444\n","payload":{"action":"remove","data":"bfe1d4da-9de1-43d8-9a05-05a1203383cf"},"sessionId":"51bbd2a7-c4fd-4949-b609-baa76b8d45b9","timestamp":1660872714025}
```

The `action` field is used to differentiate between highlight creation and removal. When removed, only the ID of the highlight is logged (which can be mapped back to its corresponding creation log).

This should allow us to create something like a heatmap of highlights in the future.