### PR TITLE
Run jest serially to avoid CI timeout

### DIFF
--- a/js-extensions/jest-puppeteer.config.js
+++ b/js-extensions/jest-puppeteer.config.js
@@ -3,6 +3,6 @@ module.exports = {
     command: "cd .. && mdbook serve -n 0.0.0.0",
     host: "0.0.0.0",
     port: 3000,
-    launchTimeout: 20000,
+    launchTimeout: 35000,
   },
 };

--- a/js-extensions/package.json
+++ b/js-extensions/package.json
@@ -5,7 +5,7 @@
         "clean": "(pnpm -r --parallel exec rm -rf dist node_modules) && rm -rf node_modules",
         "build": "pnpm run -r build",
         "watch": "pnpm run --parallel --no-bail -r build -w",
-        "test": "jest",
+        "test": "jest --runInBand",
         "fmt": "prettier -w \"packages/*/lib/**/*.{ts,tsx}\"",
         "lint": "pnpm -r --parallel exec eslint --ext js,ts,tsx lib",
         "commit-check": "pnpm clean; pnpm init-repo && pnpm lint && pnpm test"


### PR DESCRIPTION
The jest-puppeteer tests have been flaky recently due to timeouts waiting for the rust-book server starting. It looks like this can be caused by the [environment not allocating enough threads](https://github.com/smooth-code/jest-puppeteer#running-puppeteer-in-ci-environments) to run puppeteer and the server in parallel. Using this new jest command will force the tests to run in a single thread.