### PR TITLE
Update ch18-03: Rename "object safe" to "dyn compatible"

### DIFF
--- a/src/ch18-03-oo-design-patterns.md
+++ b/src/ch18-03-oo-design-patterns.md
@@ -357,9 +357,11 @@ another design pattern.
 Another downside is that we’ve duplicated some logic. To eliminate some of the
 duplication, we might try to make default implementations for the
 `request_review` and `approve` methods on the `State` trait that return `self`;
-however, this would violate object safety, because the trait doesn’t know what
+however, this would violate dyn compatibility, because the trait doesn’t know what
 the concrete `self` will be exactly. We want to be able to use `State` as a
-trait object, so we need its methods to be object safe.
+trait object, so we need its methods to be compatible with trait objects–this is 
+known as dyn compatible. In older documentation, this concept is often referred to
+as object safety.
 
 Other duplication includes the similar implementations of the `request_review`
 and `approve` methods on `Post`. Both methods delegate to the implementation of


### PR DESCRIPTION
Rename "object safe" to "dyn compatible" in ch18-03; see #291
Tracking issue: https://github.com/rust-lang/rust/issues/130852