### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ look right, but you *will* still be able to build the book. To use the plugins,
 you should run:
 
 ```bash
-$ cargo install --locked --path packages/mdbook-trpl-listing
-$ cargo install --locked --path packages/mdbook-trpl-note
+$ cargo install --locked --path packages/mdbook-trpl
 ```
 
 ## Building


### PR DESCRIPTION
Update install instructions to use preprocessors provided by packages/mdbook-trpl. It appears that this is the package being kept in sync with the upstream book instead of packages/mdbook-trpl-listing and packages/mdbook-trpl-note. This stopped my build from failing.