### PR TITLE
Remove unecessary whitespaces

### DIFF
--- a/quizzes/ch10-04-inventory.toml
+++ b/quizzes/ch10-04-inventory.toml
@@ -175,7 +175,7 @@ struct TestResult {
     curve: Option<usize>
 }
 impl TestResult {  
-    pub fn get_curve(&self) -> &Option<usize> { 
+    pub fn get_curve(&self) -> &Option<usize> {
         &self.curve
     }
 
@@ -222,7 +222,7 @@ struct TestResult {
     curve: Option<usize>
 }
 impl TestResult {  
-    pub fn get_curve(&self) -> &Option<usize> { 
+    pub fn get_curve(&self) -> &Option<usize> {
         &self.curve
     }
 
@@ -310,7 +310,7 @@ struct TestResult {
     curve: Option<usize>
 }
 impl TestResult {  
-    pub fn get_curve(&self) -> &Option<usize> { 
+    pub fn get_curve(&self) -> &Option<usize> {
         &self.curve
     }
 


### PR DESCRIPTION
Remove an unnecessary whitespace from a quiz's code snippet