### PR TITLE
Fix faulty hyperlink in src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md

### DIFF
--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -298,7 +298,7 @@ The glob operator is often used when testing to bring everything under test into
 the `tests` module; we’ll talk about that in [“How to Write
 Tests”][writing-tests]<!-- ignore --> in Chapter 11. The glob operator is also
 sometimes used as part of the prelude pattern: see [the standard library
-documentation](../std/prelude/index.html#other-preludes)<!-- ignore --> for more
+documentation](https://doc.rust-lang.org/std/prelude/index.html#other-preludes)<!-- ignore --> for more
 information on that pattern.
 
 {{#quiz ../quizzes/ch07-04-use.toml}}


### PR DESCRIPTION
Fixed a broken hyperlink in chapter 7.4 that pointed to an incorrect URL.

The corrected link now points to the proper section of the standard library documentation - I looked up the correct URL via the standard edition of the Rust book.