### PR TITLE
Fix wrong variable name in text describing listing

### DIFF
--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -171,8 +171,6 @@ to use a `for` loop to get immutable references to each element in a vector of
 
 </Listing>
 
-To read the number that `n_ref` refers to, we have to use the `*` dereference operator to get to the value in `n_ref` before we can add 1 to it, as covered in ["Dereferencing a Pointer Accesses Its Data"][deref].
-
 We can also iterate over mutable references to each element in a mutable vector
 in order to make changes to all the elements. The `for` loop in Listing 8-8
 will add `50` to each element.
@@ -185,7 +183,7 @@ will add `50` to each element.
 
 </Listing>
 
-To change the value that the mutable reference refers to, we again use the `*` dereference operator to get to the value in `n_ref` before we can use the `+=` operator. 
+To change the value that the mutable reference refers to, we again use the `*` dereference operator to get to the value in `i` before we can use the `+=` operator. 
 <!-- END INTERVENTION -->
 
 {{#quiz ../quizzes/ch08-01-vec-sec1.toml}}

--- a/src/ch08-01-vectors.md
+++ b/src/ch08-01-vectors.md
@@ -183,7 +183,7 @@ will add `50` to each element.
 
 </Listing>
 
-To change the value that the mutable reference refers to, we again use the `*` dereference operator to get to the value in `i` before we can use the `+=` operator. 
+To change the value that the mutable reference refers to, we use the `*` dereference operator to get to the value in `i` before we can use the `+=` operator. 
 <!-- END INTERVENTION -->
 
 {{#quiz ../quizzes/ch08-01-vec-sec1.toml}}


### PR DESCRIPTION
- n_ref renamed to i, reflecting the listing
- Removed sentence about needing to dereference the variable to add 1 to it, because the listing does not contain this

<img width="965" height="767" alt="image" src="https://github.com/user-attachments/assets/1322780f-3b6f-49f2-8dfd-af6f3fa3eb53" />

Fixes issue #310 