### PR TITLE
Improved grammar

### DIFF
--- a/src/ch04-02-references-and-borrowing.md
+++ b/src/ch04-02-references-and-borrowing.md
@@ -66,7 +66,7 @@ The expression `&m1` uses the ampersand operator to create a reference to (or "b
 
 Observe at L2 that there are two steps from `g1` to the string "Hello". `g1` is a reference that points to `m1` on the stack, and `m1` is a String containing a box that points to "Hello" on the heap.
 
-While `m1` owns the heap data "Hello", `g1` does _not_ own either `m1` or "Hello". Therefore after `greet` ends and the program reaches L3, no heap data has been deallocated. Only the stack frame for `greet` disappears. This fact is consistent with our *Box Deallocation Principle*. Because `g1` did not own "Hello", Rust did not deallocate "Hello" on behalf of `g1`.
+While `m1` owns the heap data "Hello", `g1` does _not_ own neither `m1` nor "Hello". Therefore after `greet` ends and the program reaches L3, no heap data has been deallocated. Only the stack frame for `greet` disappears. This fact is consistent with our *Box Deallocation Principle*. Because `g1` did not own "Hello", Rust did not deallocate "Hello" on behalf of `g1`.
 
 References are **non-owning pointers**, because they do not own the data they point to.
 


### PR DESCRIPTION
This PR does not close any issue.
I just improved slightly on grammar.
in the file ch04-02-references-and-borrowing, I changed "`g1` does _not_ own either `m1` or "Hello"." to "`g1` does _not_ own neither `m1` nor "Hello"."