### PR TITLE
Fix typo in async traits quiz context

### DIFF
--- a/quizzes/async-05-traits-for-async.toml
+++ b/quizzes/async-05-traits-for-async.toml
@@ -57,7 +57,7 @@ async fn example(x: i32) -> i32 {
 ```
 """
 context = """
-The core problem addressed by pinning in self-reference, or a future which contains a pointer to itself. 
+The core problem addressed by pinning is self-reference, or a future which contains a pointer to itself. 
 This happens when an async block contains a local variable that refers to another local variable in the future.
 Here, that would be `y = &x`.
 """


### PR DESCRIPTION
Changed “pinning in self-reference” to “pinning is self-reference”.