### PR TITLE
Update GitHub link in introduction chapter

### DIFF
--- a/src/ch00-00-introduction.md
+++ b/src/ch00-00-introduction.md
@@ -193,4 +193,4 @@ doesn’t compile.
 The source files from which this book is generated can be found on
 [GitHub][book].
 
-[book]: https://github.com/rust-lang/book/tree/main/src
+[book]: https://github.com/cognitive-engineering-lab/rust-book/tree/main/src


### PR DESCRIPTION
This PR updates the source link in the documentation to reference the correct GitHub repository.
The current link points to the official Rust repository (rust-lang/book), but this book is generated from the cognitive-engineering-lab/rust-book repository.