### PR TITLE
Fix a broken link to rust reference.

### DIFF
--- a/src/ch10-03-lifetime-syntax.md
+++ b/src/ch10-03-lifetime-syntax.md
@@ -629,5 +629,5 @@ Rust so you can make sure your code is working the way it should.
 
 [references-and-borrowing]: ch04-02-references-and-borrowing.html#references-and-borrowing
 [string-slices-as-parameters]: ch04-04-slices.html#string-slices-as-parameters
-[reference]: ../reference/index.html
+[reference]: https://doc.rust-lang.org/reference/index.html
 [lifetime-permissions]: ch04-02-references-and-borrowing.html#permissions-are-returned-at-the-end-of-a-references-lifetime


### PR DESCRIPTION
../reference/index.html returns 404 on https://rust-book.cs.brown.edu/, so hardcoded it to https://doc.rust-lang.org/reference/index.html