### PR TITLE
Fix broken link on ch07-04 standard library doc

### DIFF
--- a/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
+++ b/src/ch07-04-bringing-paths-into-scope-with-the-use-keyword.md
@@ -298,7 +298,7 @@ The glob operator is often used when testing to bring everything under test into
 the `tests` module; we’ll talk about that in [“How to Write
 Tests”][writing-tests]<!-- ignore --> in Chapter 11. The glob operator is also
 sometimes used as part of the prelude pattern: see [the standard library
-documentation](../std/prelude/index.html#other-preludes)<!-- ignore --> for more
+documentation](https://doc.rust-lang.org/std/prelude/index.html#other-preludes)<!-- ignore --> for more
 information on that pattern.
 
 {{#quiz ../quizzes/ch07-04-use.toml}}


### PR DESCRIPTION
Fixes the issue with the 404 document not found page when accessing the Standard Library documentation link

This PR fixes [Issue #367: Chapter 7.4 Broken Link: Standard Library Documentation](https://github.com/cognitive-engineering-lab/rust-book/issues/367)