### PR TITLE
fix: clear current range when no text selected

### DIFF
--- a/js-extensions/packages/feedback/lib/selection.tsx
+++ b/js-extensions/packages/feedback/lib/selection.tsx
@@ -45,6 +45,12 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
     let selection = document.getSelection();
     if (!selection) return;
 
+    // if no text is selected, clear the current range
+    if (selection.isCollapsed) {
+      setCurrRange(null);
+      return;
+    }
+
     let anchor = selection.anchorNode;
     if (!anchor) return;
 
@@ -57,7 +63,7 @@ let SelectionRenderer: React.FC<SelectionRendererProps> = ({ highlighter, stored
     if (!parentElement.closest(".content") || parentElement.closest(".aquascope, .mdbook-quiz"))
       return;
 
-    let range = !selection.isCollapsed && selection.rangeCount && selection.getRangeAt(0);
+    let range = selection.rangeCount && selection.getRangeAt(0);
 
     setCurrRange(range || null);
   }, []);


### PR DESCRIPTION
## Fix: Close feedback modal when selection is cleared

When a user triple-clicks to select text and the feedback tooltip appears, clicking elsewhere to deselect the text would clear the highlight but leave the modal/tooltip visible.

This change detects when the selection is collapsed (no text selected) and clears the current range, which properly hides the feedback tooltip/modal.

### Before
![rust-book-selection-before](https://github.com/user-attachments/assets/1bb977d6-7b56-437c-8de5-035bad2a255d)

### After
![rust-book-selection-after](https://github.com/user-attachments/assets/6c6c337b-2d15-4058-8427-a46dcfb0ed8e)