### PR TITLE
Update termination link to point to official Rust docs

### DIFF
--- a/src/ch09-02-recoverable-errors-with-result.md
+++ b/src/ch09-02-recoverable-errors-with-result.md
@@ -535,4 +535,4 @@ cases.
 
 [handle_failure]: ch02-00-guessing-game-tutorial.html#handling-potential-failure-with-result
 [trait-objects]: ch18-02-trait-objects.html#using-trait-objects-that-allow-for-values-of-different-types
-[termination]: ../std/process/trait.Termination.html
+[termination]: https://doc.rust-lang.org/std/process/trait.Termination.html


### PR DESCRIPTION
Updates the broken termination trait link in ch 9.2 to point to the official Rust docs. This works in the official Rust book because it's at the same domain as the docs, but not on the brown.edu version.