### PR TITLE
ch18-05 Fix broken link to druid widgets

### DIFF
--- a/src/ch18-05-design-challenge.md
+++ b/src/ch18-05-design-challenge.md
@@ -85,7 +85,7 @@ Along with each quiz, we have also provided links to popular Rust crates that se
 {{#quiz ../quizzes/ch17-05-design-challenge-trait-trees.toml}}
 
 [Yew components]: https://docs.rs/yew/0.20.0/yew/html/trait.Component.html
-[Druid widgets]: https://docs.rs/druid/0.8.3/druid/trait.Widget.html
+[Druid widgets]: https://docs.rs/druid/0.8.3/druid/widget/trait.Widget.html
 
 ## Dispatch
 


### PR DESCRIPTION
Before link:
<img width="1104" height="367" alt="Screenshot 2026-05-29 at 3 51 22 AM" src="https://github.com/user-attachments/assets/ddaec231-f71d-42ce-8c0b-8adccc99fbaf" />

After link:
<img width="1230" height="729" alt="Screenshot 2026-05-29 at 3 50 23 AM" src="https://github.com/user-attachments/assets/0e9c6ae5-c3c0-4ecf-8fc2-d33aa9506381" />
