### PR TITLE
fix: resolve typo in async quiz

### DIFF
--- a/quizzes/async-05-traits-for-async.toml
+++ b/quizzes/async-05-traits-for-async.toml
@@ -25,7 +25,7 @@ prompt.distractors = [
 ```rust
 async fn example(x: &i32) -> i32 {
     sleep(Duration::from_secs(1)).await;
-    *y
+    *x
 }
 ```
 """,


### PR DESCRIPTION
### Description
Fixes a typo in an `async` quiz question where an undeclared variable (`y`) is used instead of the function parameter (`x`).

### Changes
* Updated `*y` to `*x` in the code block option for Question 2.

### Context
In the third quiz option:
```rust
async fn example(x: &i32) -> i32 {
    sleep(Duration::from_secs(1)).await;
    *y // <--- 'y' is undeclared here. It should dereference the parameter 'x'.
}
```